### PR TITLE
Add local storage functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.inputValidationSubjectLength": 72
+}

--- a/pages/about.test.tsx
+++ b/pages/about.test.tsx
@@ -2,13 +2,13 @@ import { render, screen } from '@testing-library/react';
 import About from './about.page';
 
 describe('<About />', () => {
-  it('should render without crashing', async () => {
+  it('should render without crashing', () => {
     // Act
     render(<About />);
 
     // Assert
     expect(
-      screen.getByRole('heading', { name: 'about:about' })
+      screen.queryByRole('heading', { name: 'about:about' })
     ).toBeInTheDocument();
   });
 });

--- a/pages/add-habit.test.tsx
+++ b/pages/add-habit.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import AddHabit from './add-habit';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({}),
+}));
+
+describe('AddHabit', () => {
+  it('should render without crashing', () => {
+    render(<AddHabit />);
+
+    expect(
+      screen.queryByRole('heading', { name: 'add-habit:title' })
+    ).toBeInTheDocument();
+  });
+});

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from '../src/components/Link';
 import ViewHabits from '../components/ViewHabits';
+import habitsApi from '../src/api/habits';
+import Button from '../components/Button';
 
 export async function getStaticProps({ locale = 'en' }) {
   return {
@@ -76,6 +78,8 @@ const Home = () => {
       <main css={styles.main}>
         <h1 css={styles.title}>{t('app:welcome')}</h1>
         <ViewHabits />
+
+        <Button onClick={habitsApi.saveDefaultData}>save default habits</Button>
 
         <p>
           <Link href='/about'>{t('app:links.about')}</Link>

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -39,7 +39,15 @@ const jsonHabitServiceFactory = (): HabitService => {
   };
 
   const saveHabits = (habits: GoalWithHabitHistory[]) => {
-    localStorage.setItem('habits', JSON.stringify(habits));
+    try {
+      localStorage.setItem('habits', JSON.stringify(habits));
+    } catch (error) {
+      return Promise.reject(
+        new Error('Failed to save habits to local storage.')
+      );
+    }
+
+    return Promise.resolve('Saved habits successfully.');
   };
 
   // Save a default set of habits to local storage
@@ -50,7 +58,7 @@ const jsonHabitServiceFactory = (): HabitService => {
       .then((json) => saveHabits(parseJsonHabits(JSON.stringify(json))));
   };
 
-  return { addHabit, getHabits, saveDefaultData };
+  return { addHabit, getHabits, saveHabits, saveDefaultData };
 };
 
 export default jsonHabitServiceFactory;

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -9,24 +9,48 @@ const jsonHabitServiceFactory = (): HabitService => {
   const addHabit = (): Promise<string> =>
     Promise.resolve('adding habit in ze factorie');
 
-  const getHabits = (): Promise<GoalWithHabitHistory[]> =>
-    fetch('../data/habits.json')
-      .then((res) => res.json() as Promise<Response>)
-      .then((json) =>
-        json.map(({ habits, ...rest }) => ({
-          ...rest,
-          habits: habits.map(({ entries, frequency, ...restHabits }) => ({
-            ...restHabits,
-            frequency: frequency as Frequency,
-            entries: entries.map(({ completionDate, ...restEntries }) => ({
-              ...restEntries,
-              completionDate: new Date(completionDate),
-            })),
-          })),
-        }))
-      );
+  const parseJsonHabits = (json: string) => {
+    const jsonHabits = JSON.parse(json) as unknown as Response;
 
-  return { addHabit, getHabits };
+    return jsonHabits.map(({ habits, ...rest }) => ({
+      ...rest,
+      habits: habits.map(({ entries, frequency, ...restHabits }) => ({
+        ...restHabits,
+        frequency: frequency as Frequency,
+        entries: entries.map(({ completionDate, ...restEntries }) => ({
+          ...restEntries,
+          completionDate: new Date(completionDate),
+        })),
+      })),
+    }));
+  };
+
+  const getHabits = (): Promise<GoalWithHabitHistory[]> => {
+    const localHabits = localStorage.getItem('habits');
+    console.log('localHabits', localHabits);
+    if (!localHabits) return Promise.reject(new Error('No habits found'));
+
+    try {
+      return Promise.resolve(parseJsonHabits(localHabits));
+    } catch (error) {
+      console.error('Error fetching habits');
+      return Promise.reject(new Error('Failed to fetch habits'));
+    }
+  };
+
+  const saveHabits = (habits: GoalWithHabitHistory[]) => {
+    localStorage.setItem('habits', JSON.stringify(habits));
+  };
+
+  // Save a default set of habits to local storage
+  const saveDefaultData = () => {
+    console.log('saving default data');
+    fetch('../data/habits.json')
+      .then((res) => res.json())
+      .then((json) => saveHabits(parseJsonHabits(JSON.stringify(json))));
+  };
+
+  return { addHabit, getHabits, saveDefaultData };
 };
 
 export default jsonHabitServiceFactory;

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -53,9 +53,10 @@ const jsonHabitServiceFactory = (): HabitService => {
   // Save a default set of habits to local storage
   const saveDefaultData = () => {
     console.log('saving default data');
-    fetch('../data/habits.json')
+    return fetch('../data/habits.json')
       .then((res) => res.json())
-      .then((json) => saveHabits(parseJsonHabits(JSON.stringify(json))));
+      .then((json) => saveHabits(parseJsonHabits(JSON.stringify(json))))
+      .then(() => Promise.resolve());
   };
 
   return { addHabit, getHabits, saveHabits, saveDefaultData };

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -6,8 +6,7 @@ import { Frequency, GoalWithHabitHistory } from '../../../types/habits';
 type Response = typeof habitsData;
 
 const jsonHabitServiceFactory = (): HabitService => {
-  const addHabit = (): Promise<string> =>
-    Promise.resolve('adding habit in ze factorie');
+  const addHabit = (): Promise<void> => Promise.resolve();
 
   const parseJsonHabits = (json: string) => {
     const jsonHabits = JSON.parse(json) as unknown as Response;
@@ -27,7 +26,6 @@ const jsonHabitServiceFactory = (): HabitService => {
 
   const getHabits = (): Promise<GoalWithHabitHistory[]> => {
     const localHabits = localStorage.getItem('habits');
-    console.log('localHabits', localHabits);
     if (!localHabits) return Promise.resolve([]);
 
     try {
@@ -47,17 +45,15 @@ const jsonHabitServiceFactory = (): HabitService => {
       );
     }
 
-    return Promise.resolve('Saved habits successfully.');
+    return Promise.resolve();
   };
 
   // Save a default set of habits to local storage
-  const saveDefaultData = () => {
-    console.log('saving default data');
-    return fetch('../data/habits.json')
+  const saveDefaultData = () =>
+    fetch('../data/habits.json')
       .then((res) => res.json())
       .then((json) => saveHabits(parseJsonHabits(JSON.stringify(json))))
       .then(() => Promise.resolve());
-  };
 
   return { addHabit, getHabits, saveHabits, saveDefaultData };
 };

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -28,7 +28,7 @@ const jsonHabitServiceFactory = (): HabitService => {
   const getHabits = (): Promise<GoalWithHabitHistory[]> => {
     const localHabits = localStorage.getItem('habits');
     console.log('localHabits', localHabits);
-    if (!localHabits) return Promise.reject(new Error('No habits found'));
+    if (!localHabits) return Promise.resolve([]);
 
     try {
       return Promise.resolve(parseJsonHabits(localHabits));

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -7,5 +7,6 @@ export type HabitService = {
   set?: () => {};
   addHabit: () => Promise<string>;
   getHabits: () => Promise<GoalWithHabitHistory[]>;
+  saveHabits: (habits: GoalWithHabitHistory[]) => Promise<string>;
   saveDefaultData: () => void;
 };

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -5,8 +5,8 @@ export type HabitService = {
   retrieve?: () => {};
   get?: () => {};
   set?: () => {};
-  addHabit: () => Promise<string>;
+  addHabit: () => Promise<void>;
   getHabits: () => Promise<GoalWithHabitHistory[]>;
-  saveHabits: (habits: GoalWithHabitHistory[]) => Promise<string>;
+  saveHabits: (habits: GoalWithHabitHistory[]) => Promise<void>;
   saveDefaultData: () => Promise<void>;
 };

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -7,4 +7,5 @@ export type HabitService = {
   set?: () => {};
   addHabit: () => Promise<string>;
   getHabits: () => Promise<GoalWithHabitHistory[]>;
+  saveDefaultData: () => void;
 };

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -8,5 +8,5 @@ export type HabitService = {
   addHabit: () => Promise<string>;
   getHabits: () => Promise<GoalWithHabitHistory[]>;
   saveHabits: (habits: GoalWithHabitHistory[]) => Promise<string>;
-  saveDefaultData: () => void;
+  saveDefaultData: () => Promise<void>;
 };


### PR DESCRIPTION
Currently, the app doesn't actually have the ability to save any data changes that are made in the UI. It just loads data from the `habits.json` file.

This PR adds functionality to fetch habits from local storage, and adds a button to save the sample habits data we already have in `habits.json` to local storage as a starting point for testing without having to manually populate data when running the app.

It is currently a rudimentary implementation just saves and retrieve all habits data each time. This is inefficient for removing or editing 1 habit out of 15, for example, but for now, saving each habit with its own unique key is going to take more work for little gain feature-wise.

Implements #52.