### PR TITLE
Add button to delete a habit

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -5,6 +5,11 @@ const styles = {
     padding: '0.5em 2em',
     color: '#000',
     backgroundColor: '#91E220',
+
+    ':hover': {
+      cursor: 'pointer',
+      filter: 'brightness(85%)',
+    },
   }),
 };
 

--- a/components/ButtonWithIcon.tsx
+++ b/components/ButtonWithIcon.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { ReactNode } from 'react';
 import Button from './Button';
 
@@ -17,12 +17,19 @@ type IconProps = {
   source?: string;
   altText: string;
   children: ReactNode;
+  stylesProp?: SerializedStyles;
   dark?: boolean;
   onClick?: () => void;
 };
 
-const ButtonWithIcon = ({ source, altText, children, ...props }: IconProps) => (
-  <Button stylesProp={styles.iconStyle} {...props}>
+const ButtonWithIcon = ({
+  source,
+  altText,
+  children,
+  stylesProp,
+  ...props
+}: IconProps) => (
+  <Button stylesProp={{ ...styles.iconStyle, ...stylesProp }} {...props}>
     {children}
   </Button>
 );

--- a/components/ButtonWithIcon.tsx
+++ b/components/ButtonWithIcon.tsx
@@ -1,23 +1,29 @@
 import { css } from '@emotion/react';
-import Image from 'next/image';
+import { ReactNode } from 'react';
 import Button from './Button';
 
 const styles = {
   iconStyle: css({
-    padding: '0.5em 0.7em',
+    padding: '0.5em 0.5em',
     background: 'none',
     border: 'none',
+    color: '#fff',
+    minHeight: '32px',
+    minWidth: '32px',
   }),
 };
 
 type IconProps = {
-  source: string;
+  source?: string;
   altText: string;
+  children: ReactNode;
+  dark?: boolean;
+  onClick?: () => void;
 };
 
-const ButtonWithIcon = ({ source, altText, ...props }: IconProps) => (
+const ButtonWithIcon = ({ source, altText, children, ...props }: IconProps) => (
   <Button stylesProp={styles.iconStyle} {...props}>
-    <Image src={source} alt={altText} width='32' height='32' />
+    {children}
   </Button>
 );
 

--- a/components/ButtonWithImage.tsx
+++ b/components/ButtonWithImage.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+import Image from 'next/image';
+import Button from './Button';
+
+const styles = {
+  iconStyle: css({
+    padding: '0.5em 0.7em',
+    background: 'none',
+    border: 'none',
+  }),
+};
+
+type IconProps = {
+  source: string;
+  altText: string;
+};
+
+const ButtonWithImage = ({ source, altText, ...props }: IconProps) => (
+  <Button stylesProp={styles.iconStyle} {...props}>
+    <Image src={source} alt={altText} width='32' height='32' />
+  </Button>
+);
+
+export default ButtonWithImage;

--- a/components/Habits/HabitDailyView.tsx
+++ b/components/Habits/HabitDailyView.tsx
@@ -22,6 +22,14 @@ const styles = {
     gap: '8px',
   }),
 
+  deleteButton: css({
+    marginRight: '12px',
+    padding: '7px',
+    background: 'none',
+    border: 'none',
+    color: '#fff',
+  }),
+
   middleContainer: css({
     display: 'flex',
     flexDirection: 'column',
@@ -91,6 +99,7 @@ const HabitDailyView = ({
         <ButtonWithIcon
           altText='Delete'
           onClick={() => onDeleteHabit(habitWithHistory.id)}
+          stylesProp={styles.deleteButton}
         >
           <FaTrash size={24} />
         </ButtonWithIcon>

--- a/components/Habits/HabitDailyView.tsx
+++ b/components/Habits/HabitDailyView.tsx
@@ -2,14 +2,17 @@ import { css } from '@emotion/react';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 import { FaTrash } from 'react-icons/fa';
+import { useState } from 'react';
 import { HabitWithHistory } from '../../src/types/habits';
 import ButtonWithIcon from '../ButtonWithIcon';
 import CompleteButton from '../entries/CompleteButton';
+import Modal from '../Modal';
 import {
   calculateCompletionPercentages,
   getEntriesForDay,
   isBinaryHabit,
 } from './utils';
+import Button from '../Button';
 
 const styles = {
   content: css({
@@ -28,6 +31,9 @@ const styles = {
     background: 'none',
     border: 'none',
     color: '#fff',
+  }),
+  modalActions: css({
+    marginTop: '1em',
   }),
 
   middleContainer: css({
@@ -81,6 +87,8 @@ const HabitDailyView = ({
     dates: [date],
   });
 
+  const [showModal, setShowModal] = useState(false);
+
   const entriesToday = getEntriesForDay(
     habitWithHistory.entries,
     new Date().toDateString()
@@ -93,12 +101,27 @@ const HabitDailyView = ({
     else onAddHabitEntry();
   };
 
+  const confirmDelete = () => setShowModal(true);
+
   return (
     <div css={styles.content}>
+      <Modal
+        show={showModal}
+        title='Confirm deletion'
+        onClose={() => setShowModal(false)}
+      >
+        Are you sure you want to delete habit: {habitWithHistory.name}?
+        <div css={styles.modalActions}>
+          <Button onClick={() => setShowModal(false)}>Cancel</Button>
+          <Button onClick={() => onDeleteHabit(habitWithHistory.id)}>
+            Delete
+          </Button>
+        </div>
+      </Modal>
       <div css={styles.streakContainer}>
         <ButtonWithIcon
           altText='Delete'
-          onClick={() => onDeleteHabit(habitWithHistory.id)}
+          onClick={confirmDelete}
           stylesProp={styles.deleteButton}
         >
           <FaTrash size={24} />

--- a/components/Habits/HabitDailyView.tsx
+++ b/components/Habits/HabitDailyView.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
+import { FaTrash } from 'react-icons/fa';
 import { HabitWithHistory } from '../../src/types/habits';
+import ButtonWithIcon from '../ButtonWithIcon';
 import CompleteButton from '../entries/CompleteButton';
 import {
   calculateCompletionPercentages,
@@ -54,6 +56,7 @@ type HabitDailyViewProps = {
   date: string;
   onAddHabitEntry: () => void;
   onRemoveHabitEntry: (entryId: string) => void;
+  onDeleteHabit: (habitId: string) => void;
 };
 
 const HabitDailyView = ({
@@ -62,6 +65,7 @@ const HabitDailyView = ({
   date,
   onAddHabitEntry,
   onRemoveHabitEntry,
+  onDeleteHabit,
 }: HabitDailyViewProps) => {
   const { t } = useTranslation(['common', 'habit']);
   const completionPercentagesByDay = calculateCompletionPercentages({
@@ -84,6 +88,12 @@ const HabitDailyView = ({
   return (
     <div css={styles.content}>
       <div css={styles.streakContainer}>
+        <ButtonWithIcon
+          altText='Delete'
+          onClick={() => onDeleteHabit(habitWithHistory.id)}
+        >
+          <FaTrash size={24} />
+        </ButtonWithIcon>
         <Image
           src='/images/fire.svg'
           alt={t('habit:alt.fire')}

--- a/components/Habits/ViewHabits.tsx
+++ b/components/Habits/ViewHabits.tsx
@@ -125,6 +125,15 @@ const ViewHabits = () => {
       );
   };
 
+  const deleteHabit = (habitId: string) =>
+    habitsApi
+      .deleteHabit(habitId)
+      .then(() => habitsApi.getHabits())
+      .then(setHabitsData)
+      .catch((error) =>
+        logger.error('deleteHabit encountered an issue', error)
+      );
+
   return (
     <div css={styles.container}>
       <Button stylesProp={styles.toggleTimeViewButton} onClick={toggleTimeView}>
@@ -180,6 +189,7 @@ const ViewHabits = () => {
                 onRemoveHabitEntry={(entryId) =>
                   removeHabitEntry(habitWithHistory.id, entryId)
                 }
+                onDeleteHabit={deleteHabit}
               />
             ))
           )}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ReactNode, MouseEvent } from 'react';
 import { ReactNode } from 'react';
 import Button from './Button';
 
@@ -42,9 +43,15 @@ type ModalProps = {
   title: string;
 };
 
-const Modal = ({ children, show, onClose, title }: ModalProps) =>
-  show ? (
-    <div css={styles.container}>
+const Modal = ({ children, show, onClose, title }: ModalProps) => {
+  const handleOnClick = (event: MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+  
+  return show ? (
+    <div css={styles.container} onClick={handleOnClick} role='presentation'>
       <div
         css={styles.content}
         role='dialog'
@@ -59,5 +66,6 @@ const Modal = ({ children, show, onClose, title }: ModalProps) =>
       </div>
     </div>
   ) : null;
+};
 
 export default Modal;

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ReactNode, MouseEvent } from 'react';
-import { ReactNode } from 'react';
+import useKey from '../src/hooks/useKey';
 import Button from './Button';
 
 const styles = {
@@ -49,7 +49,9 @@ const Modal = ({ children, show, onClose, title }: ModalProps) => {
       onClose();
     }
   };
-  
+
+  useKey('Escape', () => onClose());
+
   return show ? (
     <div css={styles.container} onClick={handleOnClick} role='presentation'>
       <div

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+import { ReactNode } from 'react';
+import Button from './Button';
+
+const styles = {
+  container: css({
+    position: 'fixed',
+    zIndex: 1,
+    background: 'rgba(0, 0, 52, 0.5)',
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+  }),
+  content: css({
+    width: '90%',
+    backgroundColor: '#333',
+    margin: '10% auto',
+    padding: '2em 1em 2em 1em',
+    position: 'relative',
+    opacity: '100%',
+
+    '@media (min-width: 800px)': {
+      width: '70%',
+    },
+
+    '@media (min-width: 1280px)': {
+      width: '40%',
+    },
+  }),
+  closeButton: css({
+    position: 'absolute',
+    top: '15px',
+    right: '15px',
+  }),
+};
+
+type ModalProps = {
+  children: ReactNode;
+  show: boolean;
+  onClose: () => void;
+  title: string;
+};
+
+const Modal = ({ children, show, onClose, title }: ModalProps) =>
+  show ? (
+    <div css={styles.container}>
+      <div
+        css={styles.content}
+        role='dialog'
+        aria-labelledby='modal_label'
+        aria-modal='true'
+      >
+        <h1 id='modal_label'>{title}</h1>
+        <Button css={styles.closeButton} onClick={onClose} title='Cancel'>
+          &times;
+        </Button>
+        {children}
+      </div>
+    </div>
+  ) : null;
+
+export default Modal;

--- a/components/entries/CompleteButton.tsx
+++ b/components/entries/CompleteButton.tsx
@@ -1,6 +1,6 @@
 import { SerializedStyles } from '@emotion/react';
 import { useTranslation } from 'react-i18next';
-import ButtonWithIcon from '../ButtonWithIcon';
+import ButtonWithImage from '../ButtonWithImage';
 
 type CompleteButtonProps = {
   complete: boolean;
@@ -15,13 +15,13 @@ const CompleteButton = ({
   const { t } = useTranslation(['common', 'habit']);
 
   return complete ? (
-    <ButtonWithIcon
+    <ButtonWithImage
       source='/images/habit-complete.svg'
       altText={t('habit:complete')}
       {...props}
     />
   ) : (
-    <ButtonWithIcon
+    <ButtonWithImage
       source='/images/habit-incomplete.svg'
       altText={t('habit:incomplete')}
       {...props}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-i18next": "^12.1.1",
+        "react-icons": "^4.8.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -6907,6 +6908,14 @@
         }
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -12996,6 +13005,12 @@
         "@babel/runtime": "^7.20.6",
         "html-parse-stringify": "^3.0.1"
       }
+    },
+    "react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
     "i18next": "^22.4.8",
+    "lodash": "^4.17.21",
     "loglevel": "^1.8.1",
     "next": "13.0.6",
     "next-i18next": "^13.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "^12.1.1",
-    "uuid": "^9.0.0",
-    "lodash": "^4.17.21"
+    "react-icons": "^4.8.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.21",

--- a/src/api/habits/adapters/json.test.ts
+++ b/src/api/habits/adapters/json.test.ts
@@ -174,4 +174,20 @@ describe('JSON habit adapter', () => {
       expect(entries.length).toBe(originalEntries.length - 1);
     });
   });
+
+  describe('deleteHabit()', () => {
+    it('should delete a habit, given a valid habit ID', async () => {
+      const { getHabits, saveHabits, deleteHabit } = jsonHabitFactory();
+      saveHabits(habitsMockData);
+      const originalHabits = habitsMockData[0].habits;
+
+      const habitIdToDelete = originalHabits[0].id;
+      await deleteHabit(habitIdToDelete);
+
+      const [{ habits }] = await getHabits();
+      const habit = habits.find(({ id }) => id === habitIdToDelete);
+      expect(habit).not.toBeDefined();
+      expect(habits.length).toBe(originalHabits.length - 1);
+    });
+  });
 });

--- a/src/api/habits/adapters/json.ts
+++ b/src/api/habits/adapters/json.ts
@@ -134,14 +134,28 @@ const jsonHabitServiceFactory = (): HabitService => {
       )
       .catch((error) => Promise.reject(error));
 
+  const deleteHabit = (habitId: string) =>
+    getHabits()
+      .then((goals) =>
+        Promise.resolve(
+          goals.map((goal) => ({
+            ...goal,
+            habits: goal.habits.filter((habit) => habit.id !== habitId),
+          }))
+        )
+      )
+      .then(saveHabits)
+      .catch((error) => Promise.reject(error));
+
   return {
     addHabit,
+    deleteHabit,
     getHabits,
     addEntry,
     removeEntry,
     saveHabits,
     saveDefaultData,
-    getHabitsFromDate
+    getHabitsFromDate,
   };
 };
 

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -17,6 +17,7 @@ export type HabitService = {
   get?: () => {};
   set?: () => {};
   addHabit: () => Promise<string>;
+  deleteHabit: (habitId: string) => Promise<void>;
   getHabits: () => Promise<GoalWithHabitHistory[]>;
   getHabitsFromDate: (date: Date) => Promise<GoalWithHabitHistory[]>;
   saveHabits: (habits: GoalWithHabitHistory[]) => Promise<void>;

--- a/src/hooks/useKey.tsx
+++ b/src/hooks/useKey.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+const useKey = (key: string, callback: (event: Event) => void) => {
+  useEffect(() => {
+    window.addEventListener('keydown', callback);
+
+    return () => {
+      window.removeEventListener('keydown', callback);
+    };
+  }, [callback]);
+};
+
+export default useKey;


### PR DESCRIPTION
Currently, a user can add habits but there's no way of removing them.

This PR implements the ability for a user to delete a habit once it's been created. A dialog to confirm deletion stops the user from accidentally deleting something.

Implements #72.