### PR TITLE
Add notification toasts to make saving default data clearer

### DIFF
--- a/components/Habits/ViewHabits.tsx
+++ b/components/Habits/ViewHabits.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'next-i18next';
+import { ToastContainer, toast } from 'react-toastify';
 import { GoalWithHabitHistory } from '../../src/types/habits';
 import habitsApi from '../../src/api/habits';
 import Link from '../../src/components/Link';
@@ -76,6 +77,8 @@ const calculateDates = (daysToShow: number) => {
   return days;
 };
 
+const defaultDataSavedToast = () => toast('Wau!');
+
 type TimeView = 'daily' | 'weekly';
 
 const DAYS_TO_SHOW = 7;
@@ -86,6 +89,14 @@ const ViewHabits = () => {
   const [timeView, setTimeView] = useState<TimeView>('daily');
 
   const dates = calculateDates(DAYS_TO_SHOW);
+
+  const saveDefaultData = () => {
+    habitsApi
+      .saveDefaultData()
+      .then(defaultDataSavedToast)
+      .then(habitsApi.getHabits)
+      .then(setHabitsData);
+  };
 
   // Now fetch the data based on the number of days to show
   // We don't want to fetch all habits data, as it would be inefficient to pull in potentially years' worth of data
@@ -165,6 +176,8 @@ const ViewHabits = () => {
       </header>
 
       <div css={styles.habitsContainer}>
+        <Button onClick={saveDefaultData}>save default habits</Button>
+        
         {timeView === 'weekly' && (
           <HabitWeeklyView
             goals={habitsData}
@@ -194,6 +207,8 @@ const ViewHabits = () => {
             ))
           )}
       </div>
+
+      <ToastContainer />
     </div>
   );
 };

--- a/components/Habits/ViewHabits.tsx
+++ b/components/Habits/ViewHabits.tsx
@@ -176,8 +176,9 @@ const ViewHabits = () => {
       </header>
 
       <div css={styles.habitsContainer}>
-        <Button onClick={saveDefaultData}>save default habits</Button>
-        
+        {habitsData.length === 0 && (
+          <Button onClick={saveDefaultData}>save default habits</Button>
+        )}
         {timeView === 'weekly' && (
           <HabitWeeklyView
             goals={habitsData}

--- a/components/Habits/ViewHabits.tsx
+++ b/components/Habits/ViewHabits.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import { GoalWithHabitHistory } from '../../src/types/habits';
 import habitsApi from '../../src/api/habits';
 import Link from '../../src/components/Link';
@@ -77,7 +78,7 @@ const calculateDates = (daysToShow: number) => {
   return days;
 };
 
-const defaultDataSavedToast = () => toast('Wau!');
+const defaultDataSavedToast = () => toast('Goals saved successfully!');
 
 type TimeView = 'daily' | 'weekly';
 
@@ -209,7 +210,18 @@ const ViewHabits = () => {
           )}
       </div>
 
-      <ToastContainer />
+      <ToastContainer
+        position='bottom-right'
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme='dark'
+      />
     </div>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "18.2.0",
         "react-i18next": "^12.1.1",
         "react-icons": "^4.8.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "react-toastify": "^9.1.1"
       },
       "devDependencies": {
         "@swc/core": "^1.3.21",
@@ -2965,6 +2966,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -6921,6 +6930,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10133,6 +10154,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13016,6 +13042,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
     },
     "redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "18.2.0",
     "react-i18next": "^12.1.1",
     "react-icons": "^4.8.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "react-toastify": "^9.1.1"
   },
   "devDependencies": {
     "@swc/core": "^1.3.21",

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -4,9 +4,11 @@ import { css } from '@emotion/react';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Habits from '../components/Habits';
+import { ToastContainer, toast } from 'react-toastify';
 import Link from '../src/components/Link';
 import habitsApi from '../src/api/habits';
 import Button from '../components/Button';
+import 'react-toastify/dist/ReactToastify.css';
 
 export async function getStaticProps({ locale = 'en' }) {
   return {
@@ -65,6 +67,12 @@ const styles = {
   }),
 };
 
+const defaultDataSavedToast = () => toast('Wau!');
+
+const saveDefaultData = () => {
+  habitsApi.saveDefaultData().then(defaultDataSavedToast);
+};
+
 const Home = () => {
   const { t } = useTranslation();
 
@@ -80,7 +88,7 @@ const Home = () => {
         <h1 css={styles.title}>{t('app:welcome')}</h1>
         <Habits />
 
-        <Button onClick={habitsApi.saveDefaultData}>save default habits</Button>
+        <Button onClick={saveDefaultData}>save default habits</Button>
 
         <p>
           <Link href='/about'>{t('app:links.about')}</Link>
@@ -112,6 +120,7 @@ const Home = () => {
           </span>
         </a>
       </footer>
+      <ToastContainer />
     </div>
   );
 };

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -4,10 +4,7 @@ import { css } from '@emotion/react';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Habits from '../components/Habits';
-import { ToastContainer, toast } from 'react-toastify';
 import Link from '../src/components/Link';
-import habitsApi from '../src/api/habits';
-import Button from '../components/Button';
 import 'react-toastify/dist/ReactToastify.css';
 
 export async function getStaticProps({ locale = 'en' }) {
@@ -67,12 +64,6 @@ const styles = {
   }),
 };
 
-const defaultDataSavedToast = () => toast('Wau!');
-
-const saveDefaultData = () => {
-  habitsApi.saveDefaultData().then(defaultDataSavedToast);
-};
-
 const Home = () => {
   const { t } = useTranslation();
 
@@ -87,8 +78,6 @@ const Home = () => {
       <main css={styles.main}>
         <h1 css={styles.title}>{t('app:welcome')}</h1>
         <Habits />
-
-        <Button onClick={saveDefaultData}>save default habits</Button>
 
         <p>
           <Link href='/about'>{t('app:links.about')}</Link>
@@ -120,7 +109,6 @@ const Home = () => {
           </span>
         </a>
       </footer>
-      <ToastContainer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
At the moment, saving some default habits data to play around with the app requires the user to refresh the page to see the new data, which isn't a good user experience. This PR adds functionality to load the data into the habits view once the default data has been saved, and makes it clearer that we've loaded the data by displaying a toast.

Implements #67.
